### PR TITLE
Modifica 65° encontro para formato padrão

### DIFF
--- a/2020/65/README.md
+++ b/2020/65/README.md
@@ -1,23 +1,24 @@
-# 65ª Encontro do PUG-PE (21/05/2020)
+# 65ª Encontro do PUG-PE (21/05)
 
-Link da live no Youtube: https://www.youtube.com/watch?v=4UhmWKI8Rvc
+Local: [Live no Youtube](https://www.youtube.com/watch?v=4UhmWKI8Rvc)
+
+Horário:  21 de Maio de 2020 às 21:00 
 
 ## Palestras
 
 ### O poder dos métodos mágicos
-#### Palestrante: Douglas Henrique Santana da Silva
+#### douglas henrique santana da silva
 Uma palestra que irá explica o que são métodos mágicos e o poder da expressividade dos mesmos para a construção de código pythônicos
 
 ### Introdução a data science com python: explorando as bibliotecas pandas e matplot
-#### Palestrante: Natassia Rafaelle Medeiros Siqueira
-A palestra visa apresentar os conceitos básicos de data science. Explorando as duas das bibliotecas chave.
+#### Natassia Rafaelle Medeiros Siqueira
+A palestra visa apresentar os conceitos básicos de data science. Explorando as duas das bibliotecas chave. 
 
-## Palestras Relâmpago
 
 ### Usando pudb para debugar código
-#### Palestrante: Anderson Berg
+#### Anderson Berg
 pudb é um debugger Python para terminal. Ele tem funcionalidades bem úteis para quem gosta de rodar e testar programas em Python pelo terminal. É o debugger que uso diariamente no meu trabalho e mostrar como explorar essas funcionalidades nessa LT
 
 ### Apresentação da Start Coding
-#### Palestrante: Mariana Araujo Adelino
+#### Mariana Araujo Adelino
 Essa palestra relâmpago tem como objetivo apontar a desigualdade de gêneros no setor da T.I, que é alvo de discussão a muito tempo. Como forma de combater essa desigualdade, a Start Coding foi criada. Com ações de palestra, meetups, cursos, iremos promover capacitação para as mulheres que desejam entrar nessa área ou oferecer suporte as que já estão.


### PR DESCRIPTION
A ideia seria modificar o README para atender o formato gerado pelo script. Mas deixando o link da live disponível.